### PR TITLE
Add red target constant for effort normalization

### DIFF
--- a/mission/ted.py
+++ b/mission/ted.py
@@ -616,8 +616,7 @@ def compute_skills(data,msg_data, config):
 		if player_data['dig_rubble_start_time']:
 			flag_rubble=1
 
-
-		indv_msg['Effort']=player_data['effort']/config.extra_info['max_tiles']
+		indv_msg['Effort']=player_data['effort']/ (config.extra_info['max_tiles'] + config.extra_info['red_effort'])
 		msg_data['Effort']+=indv_msg['Effort']
 
 		record_skill_duration(data,'dig_rubble',player_data)
@@ -758,7 +757,7 @@ def compute_process_values(msg_data, config):
 	msg_data['Skill'] = msg_data['Skill']/num_players
 	config.state['skill_uses'].append(msg_data['Skill']/num_players)
 
-	msg_data['Effort'] =  msg_data['Effort']/num_players
+	msg_data['Effort'] = msg_data['Effort']/num_players
 	config.state['efforts'].append(msg_data['Effort'])
 
 


### PR DESCRIPTION
It looks like effort was only normalized by dividing by the maximum area covered, but we should also include the maximum target effort to set a ceiling. This lowers effort overall and may not be a perfect fix, but in my individual testing I haven't been able to get it above 100.