### PR TITLE
add min-max standardization to effort

### DIFF
--- a/mission/ted.py
+++ b/mission/ted.py
@@ -448,7 +448,6 @@ def publish_ac_result(data, config):
 	Prepares the score information and publishes a message on the bus.
 	"""
 	msg_data = prepare_ac_msg_data(data , config)
-	print(msg_data["Effort"])
 	config.state['msg_data'].append(msg_data)
 
 	# Round the scores to a reasonable amount of precision.
@@ -617,7 +616,7 @@ def compute_skills(data,msg_data, config):
 		if player_data['dig_rubble_start_time']:
 			flag_rubble=1
 
-		indv_msg['Effort']=player_data['effort'] / (config.extra_info['max_tiles'] )
+		indv_msg['Effort']=player_data['effort'] / (config.extra_info['max_tiles'])
 
 		indv_msg['Effort'] = min(indv_msg['Effort'] - 0.0 / (0.85 - 0), 1)
 

--- a/mission/ted.py
+++ b/mission/ted.py
@@ -448,6 +448,7 @@ def publish_ac_result(data, config):
 	Prepares the score information and publishes a message on the bus.
 	"""
 	msg_data = prepare_ac_msg_data(data , config)
+	print(msg_data["Effort"])
 	config.state['msg_data'].append(msg_data)
 
 	# Round the scores to a reasonable amount of precision.
@@ -616,7 +617,11 @@ def compute_skills(data,msg_data, config):
 		if player_data['dig_rubble_start_time']:
 			flag_rubble=1
 
-		indv_msg['Effort']=player_data['effort']/ (config.extra_info['max_tiles'] + config.extra_info['red_effort'])
+		indv_msg['Effort']=player_data['effort'] / (config.extra_info['max_tiles'] )
+
+		indv_msg['Effort'] = min(indv_msg['Effort'] - 0.0 / (0.85 - 0), 1)
+
+
 		msg_data['Effort']+=indv_msg['Effort']
 
 		record_skill_duration(data,'dig_rubble',player_data)


### PR DESCRIPTION
In the local version I was running, I also divided effort by 10 so that the later multiplication by 1000 would be canceled out. I've removed that here, so it'll need to be done on the plotting side (multiply by 1,000 -> multiply by 100).